### PR TITLE
Highlight exception message

### DIFF
--- a/api/MapVault.sln.DotSettings
+++ b/api/MapVault.sln.DotSettings
@@ -1,2 +1,3 @@
 ﻿<wpf:ResourceDictionary xml:space="preserve" xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml" xmlns:s="clr-namespace:System;assembly=mscorlib" xmlns:ss="urn:shemas-jetbrains-com:settings-storage-xaml" xmlns:wpf="http://schemas.microsoft.com/winfx/2006/xaml/presentation">
+	<s:Boolean x:Key="/Default/UserDictionary/Words/=Dtos/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=mapvault/@EntryIndexedValue">True</s:Boolean></wpf:ResourceDictionary>

--- a/api/MapVault.sln.DotSettings
+++ b/api/MapVault.sln.DotSettings
@@ -1,3 +1,5 @@
 ﻿<wpf:ResourceDictionary xml:space="preserve" xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml" xmlns:s="clr-namespace:System;assembly=mscorlib" xmlns:ss="urn:shemas-jetbrains-com:settings-storage-xaml" xmlns:wpf="http://schemas.microsoft.com/winfx/2006/xaml/presentation">
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=Dtos/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/UserDictionary/Words/=Erro/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/UserDictionary/Words/=existe/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=mapvault/@EntryIndexedValue">True</s:Boolean></wpf:ResourceDictionary>

--- a/api/src/Controllers/CreateNoteController.cs
+++ b/api/src/Controllers/CreateNoteController.cs
@@ -1,6 +1,7 @@
 using MapVault.Dtos;
 using MapVault.Models;
 using MapVault.Repositories;
+using MapVault.Utils;
 using Microsoft.AspNetCore.Mvc;
 using Newtonsoft.Json;
 
@@ -12,13 +13,16 @@ public class CreateNoteController : ControllerBase
 {
    private readonly ILogger<CreateNoteController> _logger;
    private readonly INotesRepository _notesRepository;
+   private readonly HighlightExceptionMessage _highlightExceptionMessage;
 
    public CreateNoteController(
       ILogger<CreateNoteController> logger,
-      INotesRepository notesRepository)
+      INotesRepository notesRepository,
+      HighlightExceptionMessage highlightExceptionMessage)
    {
       _logger = logger ?? throw new ArgumentNullException(nameof(logger));
       _notesRepository = notesRepository ?? throw new ArgumentNullException(nameof(notesRepository));
+      _highlightExceptionMessage = highlightExceptionMessage;
 
       _logger.LogInformation("CreateNoteController has been started");
    }
@@ -42,6 +46,15 @@ public class CreateNoteController : ControllerBase
       }
 
       _logger.LogInformation("CreateNote run successfully for id {Id}", note.Id);
+
+      if (request.HighlightMessage && note.ExceptionMessage.Message != null)
+      {
+#pragma warning disable CS4014
+         // Fire-and-forget
+         _highlightExceptionMessage.Highlight(note.Id, note.ExceptionMessage.Message);
+#pragma warning restore CS4014
+      }
+
       return Ok(note);
    }
 }

--- a/api/src/Controllers/CreateNoteController.cs
+++ b/api/src/Controllers/CreateNoteController.cs
@@ -3,7 +3,6 @@ using MapVault.Models;
 using MapVault.Repositories;
 using MapVault.Utils;
 using Microsoft.AspNetCore.Mvc;
-using Newtonsoft.Json;
 
 namespace MapVault.Controllers;
 
@@ -22,7 +21,7 @@ public class CreateNoteController : ControllerBase
    {
       _logger = logger ?? throw new ArgumentNullException(nameof(logger));
       _notesRepository = notesRepository ?? throw new ArgumentNullException(nameof(notesRepository));
-      _highlightExceptionMessage = highlightExceptionMessage;
+      _highlightExceptionMessage = highlightExceptionMessage ?? throw new ArgumentNullException(nameof(highlightExceptionMessage));
 
       _logger.LogInformation("CreateNoteController has been started");
    }

--- a/api/src/Controllers/DeleteNoteController.cs
+++ b/api/src/Controllers/DeleteNoteController.cs
@@ -29,7 +29,7 @@ public class DeleteNoteController : ControllerBase
       if (deleteResult is false)
       {
          _logger.LogError("Couldn't delete note for id {Id}", id);
-         return BadRequest(new DefaultErrorResponse($"Couldn't delete note. The informed Id may not exists"));
+         return BadRequest(new DefaultErrorResponse("Couldn't delete note. The informed Id may not exists"));
       }
       
       _logger.LogInformation("DeleteNote run successfully for id {Id}", id);

--- a/api/src/Controllers/GetNotesController.cs
+++ b/api/src/Controllers/GetNotesController.cs
@@ -1,5 +1,4 @@
 using MapVault.Dtos;
-using MapVault.QueryModels;
 using MapVault.Repositories;
 using Microsoft.AspNetCore.Mvc;
 

--- a/api/src/Controllers/GetValuableFromExceptionMessageController.cs
+++ b/api/src/Controllers/GetValuableFromExceptionMessageController.cs
@@ -6,22 +6,28 @@ namespace MapVault.Controllers;
 
 [ApiController]
 [Route("api/v1")]
-public class HighlightMessageController : ControllerBase
+public class GetValuableFromExceptionMessageController : ControllerBase
 {
+    private readonly ILogger<GetValuableFromExceptionMessageController> _logger;
     private readonly IHighlightMessageClient _highlightMessageClient;
 
-    public HighlightMessageController(
+    public GetValuableFromExceptionMessageController(
+        ILogger<GetValuableFromExceptionMessageController> logger,
         IHighlightMessageClient highlightMessageClient)
     {
+        _logger = logger;
         _highlightMessageClient = highlightMessageClient;
+        
+        _logger.LogInformation("GetValuableFromExceptionMessage has been started");
     }
     
     [HttpPost]
     [Route("highlight")]
-    public async Task<IActionResult> HighlightMessage([FromBody] HighlightMessageRequestDto request)
+    public async Task<IActionResult> GetValuableFromMessage([FromBody] HighlightMessageRequestDto request)
     {
         var valuables = await _highlightMessageClient.GetValuableFragments(request.Message);
         
+        _logger.LogInformation("GetValuableFromMessage run successfully");
         return Ok(new HighlightMessageResponseDto { ValuableFragments = valuables });
     }
 }

--- a/api/src/Controllers/GetValuableFromExceptionMessageController.cs
+++ b/api/src/Controllers/GetValuableFromExceptionMessageController.cs
@@ -15,10 +15,10 @@ public class GetValuableFromExceptionMessageController : ControllerBase
         ILogger<GetValuableFromExceptionMessageController> logger,
         IHighlightMessageClient highlightMessageClient)
     {
-        _logger = logger;
-        _highlightMessageClient = highlightMessageClient;
+        _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+        _highlightMessageClient = highlightMessageClient ?? throw new ArgumentNullException(nameof(highlightMessageClient));
         
-        _logger.LogInformation("GetValuableFromExceptionMessage has been started");
+        _logger.LogInformation("GetValuableFromExceptionMessageController has been started");
     }
     
     [HttpPost]

--- a/api/src/Controllers/GetValuableFromExceptionMessageController.cs
+++ b/api/src/Controllers/GetValuableFromExceptionMessageController.cs
@@ -21,7 +21,7 @@ public class GetValuableFromExceptionMessageController : ControllerBase
         _logger.LogInformation("GetValuableFromExceptionMessageController has been started");
     }
     
-    [HttpPost]
+    [HttpGet]
     [Route("highlight")]
     public async Task<IActionResult> GetValuableFromMessage([FromBody] HighlightMessageRequestDto request)
     {

--- a/api/src/Controllers/HighlightMessageController.cs
+++ b/api/src/Controllers/HighlightMessageController.cs
@@ -1,0 +1,27 @@
+using MapVault.Dtos;
+using MapVault.Http.HighlightMessage;
+using Microsoft.AspNetCore.Mvc;
+
+namespace MapVault.Controllers;
+
+[ApiController]
+[Route("api/v1")]
+public class HighlightMessageController : ControllerBase
+{
+    private readonly IHighlightMessageClient _highlightMessageClient;
+
+    public HighlightMessageController(
+        IHighlightMessageClient highlightMessageClient)
+    {
+        _highlightMessageClient = highlightMessageClient;
+    }
+    
+    [HttpPost]
+    [Route("highlight")]
+    public async Task<IActionResult> HighlightMessage([FromBody] HighlightMessageRequestDto request)
+    {
+        var valuables = await _highlightMessageClient.GetValuableFragments(request.Message);
+        
+        return Ok(new HighlightMessageResponseDto { ValuableFragments = valuables });
+    }
+}

--- a/api/src/Controllers/SearchNotesController.cs
+++ b/api/src/Controllers/SearchNotesController.cs
@@ -16,6 +16,8 @@ public class SearchController : ControllerBase
     {
         _logger = logger ?? throw new ArgumentNullException(nameof(logger));
         _notesRepository = repository ?? throw new ArgumentNullException(nameof(repository));
+        
+        _logger.LogInformation("SearchController has been started");
     }
     
     [HttpGet]

--- a/api/src/Controllers/UpdateNoteController.cs
+++ b/api/src/Controllers/UpdateNoteController.cs
@@ -55,6 +55,10 @@ public class UpdateNoteController : ControllerBase
          _highlightExceptionMessage.Highlight(note.Id, note.ExceptionMessage.Message);
 #pragma warning restore CS4014
       }
+      else
+      {
+         note.ResetExceptionMessageHighlights();
+      }
       
       return Ok(note);
    }

--- a/api/src/Controllers/UpdateNoteController.cs
+++ b/api/src/Controllers/UpdateNoteController.cs
@@ -1,5 +1,6 @@
 using MapVault.Dtos;
 using MapVault.Repositories;
+using MapVault.Utils;
 using Microsoft.AspNetCore.Mvc;
 
 namespace MapVault.Controllers;
@@ -10,13 +11,16 @@ public class UpdateNoteController : ControllerBase
 {
    private readonly ILogger<GetNotesController> _logger;
    private readonly INotesRepository _notesRepository;
+   private readonly HighlightExceptionMessage _highlightExceptionMessage;
 
    public UpdateNoteController(
       ILogger<GetNotesController> logger,
-      INotesRepository repository)
+      INotesRepository repository,
+      HighlightExceptionMessage highlightExceptionMessage)
    {
       _logger = logger ?? throw new ArgumentNullException(nameof(logger));
       _notesRepository = repository ?? throw new ArgumentNullException(nameof(repository));
+      _highlightExceptionMessage = highlightExceptionMessage;
 
       _logger.LogInformation("UpdateNoteController has been started");
    }
@@ -43,6 +47,15 @@ public class UpdateNoteController : ControllerBase
       }
 
       _logger.LogInformation("UpdateNote run successfully for id {Id}", note.Id);
+      
+      if (request.HighlightMessage && note.ExceptionMessage.Message != null)
+      {
+#pragma warning disable CS4014
+         // Fire-and-forget
+         _highlightExceptionMessage.Highlight(note.Id, note.ExceptionMessage.Message);
+#pragma warning restore CS4014
+      }
+      
       return Ok(note);
    }
 }

--- a/api/src/Controllers/UpdateNoteController.cs
+++ b/api/src/Controllers/UpdateNoteController.cs
@@ -20,7 +20,7 @@ public class UpdateNoteController : ControllerBase
    {
       _logger = logger ?? throw new ArgumentNullException(nameof(logger));
       _notesRepository = repository ?? throw new ArgumentNullException(nameof(repository));
-      _highlightExceptionMessage = highlightExceptionMessage;
+      _highlightExceptionMessage = highlightExceptionMessage ?? throw new ArgumentNullException(nameof(highlightExceptionMessage));
 
       _logger.LogInformation("UpdateNoteController has been started");
    }

--- a/api/src/DependencyInjections/DataContextExtensions.cs
+++ b/api/src/DependencyInjections/DataContextExtensions.cs
@@ -1,4 +1,3 @@
-using MapVault.Data;
 using MapVault.Repositories;
 
 namespace MapVault.DependencyInjections;

--- a/api/src/DependencyInjections/MapVaultExternalApisExtension.cs
+++ b/api/src/DependencyInjections/MapVaultExternalApisExtension.cs
@@ -1,0 +1,16 @@
+using MapVault.Http.HighlightMessage;
+using MapVault.Http.HighlightMessage.OpenAI;
+
+namespace MapVault.DependencyInjections;
+
+public static class MapVaultExternalApisExtension
+{
+    public static IServiceCollection AddExternalApis(this IServiceCollection services)
+    {
+        services.AddHttpClient();
+
+        services.AddScoped<IHighlightMessageClient, OpenAiClient>();
+
+        return services;
+    }
+}

--- a/api/src/DependencyInjections/MapVaultUtilsExtensions.cs
+++ b/api/src/DependencyInjections/MapVaultUtilsExtensions.cs
@@ -1,0 +1,13 @@
+using MapVault.Utils;
+
+namespace MapVault.DependencyInjections;
+
+public static class MapVaultUtilsExtensions
+{
+    public static IServiceCollection AddUtils(this IServiceCollection services)
+    {
+        services.AddScoped<HighlightExceptionMessage>();
+        
+        return services;
+    }
+}

--- a/api/src/Dtos/CreateNoteRequestDto.cs
+++ b/api/src/Dtos/CreateNoteRequestDto.cs
@@ -6,5 +6,6 @@ public class CreateNoteRequestDto
    public string[]? Categories { get; set; }
    public string? Description { get; set; }
    public string? ExceptionMessage { get; set; }
+   public bool HighlightMessage { get; set; }
    public string? Content { get; set; }
 }

--- a/api/src/Dtos/DefaultErrorResponse.cs
+++ b/api/src/Dtos/DefaultErrorResponse.cs
@@ -2,7 +2,7 @@ namespace MapVault.Dtos;
 
 public class DefaultErrorResponse
 {
-   public string ErrorMessage { get; set; }
+   private string ErrorMessage { get; set; }
 
    public DefaultErrorResponse(string errorMessage)
    {

--- a/api/src/Dtos/HighlightMessageRequestDto.cs
+++ b/api/src/Dtos/HighlightMessageRequestDto.cs
@@ -2,5 +2,5 @@ namespace MapVault.Dtos;
 
 public class HighlightMessageRequestDto
 {
-    public string Message { get; set; }
+    public string? Message { get; set; }
 }

--- a/api/src/Dtos/HighlightMessageRequestDto.cs
+++ b/api/src/Dtos/HighlightMessageRequestDto.cs
@@ -1,0 +1,6 @@
+namespace MapVault.Dtos;
+
+public class HighlightMessageRequestDto
+{
+    public string Message { get; set; }
+}

--- a/api/src/Dtos/HighlightMessageResponseDto.cs
+++ b/api/src/Dtos/HighlightMessageResponseDto.cs
@@ -2,5 +2,5 @@ namespace MapVault.Dtos;
 
 public class HighlightMessageResponseDto
 {
-    public string[] ValuableFragments { get; set; }
+    public IEnumerable<string> ValuableFragments { get; set; }
 }

--- a/api/src/Dtos/HighlightMessageResponseDto.cs
+++ b/api/src/Dtos/HighlightMessageResponseDto.cs
@@ -2,5 +2,5 @@ namespace MapVault.Dtos;
 
 public class HighlightMessageResponseDto
 {
-    public IEnumerable<string> ValuableFragments { get; set; }
+    public IEnumerable<string>? ValuableFragments { get; set; }
 }

--- a/api/src/Dtos/HighlightMessageResponseDto.cs
+++ b/api/src/Dtos/HighlightMessageResponseDto.cs
@@ -1,0 +1,6 @@
+namespace MapVault.Dtos;
+
+public class HighlightMessageResponseDto
+{
+    public string[] ValuableFragments { get; set; }
+}

--- a/api/src/Dtos/UpdateNoteRequestDto.cs
+++ b/api/src/Dtos/UpdateNoteRequestDto.cs
@@ -7,5 +7,6 @@ public class UpdateNoteRequestDto
    public string[]? Categories { get; set; }
    public string? Description { get; set; }
    public string? ExceptionMessage { get; set; }
+   public bool HighlightMessage { get; set; }
    public string? Content { get; set; }
 }

--- a/api/src/Http/HighlightMessage/IHighlightMessageClient.cs
+++ b/api/src/Http/HighlightMessage/IHighlightMessageClient.cs
@@ -1,0 +1,6 @@
+namespace MapVault.Http.HighlightMessage;
+
+public interface IHighlightMessageClient
+{
+    Task<string[]> GetValuableFragments(string message);
+}

--- a/api/src/Http/HighlightMessage/IHighlightMessageClient.cs
+++ b/api/src/Http/HighlightMessage/IHighlightMessageClient.cs
@@ -2,5 +2,5 @@ namespace MapVault.Http.HighlightMessage;
 
 public interface IHighlightMessageClient
 {
-    Task<string[]> GetValuableFragments(string message);
+    Task<IEnumerable<string>> GetValuableFragments(string message);
 }

--- a/api/src/Http/HighlightMessage/OpenAI/OpenAiClient.cs
+++ b/api/src/Http/HighlightMessage/OpenAI/OpenAiClient.cs
@@ -1,0 +1,58 @@
+using System.Net.Http.Headers;
+using System.Text;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Serialization;
+
+namespace MapVault.Http.HighlightMessage.OpenAI;
+
+public class OpenAiClient : IHighlightMessageClient
+{
+    private readonly JsonSerializerSettings _jsonSettings = new()
+    {
+        ContractResolver = new CamelCasePropertyNamesContractResolver()
+    };
+
+    private readonly string PromptTemplate =
+        "select 3 most important fragments in order to understand the following exception message" + 
+            "and return as plain text, separated by ';' and with no additional comments";
+
+    private readonly OpenAiSettings _settings;
+
+    public OpenAiClient(IConfiguration configuration)
+    {
+        var settings = configuration.GetSection(OpenAiSettings.OpenAiConfig).Get<OpenAiSettings>();
+        ArgumentNullException.ThrowIfNull(settings);
+        _settings = settings;
+    }
+    
+    public async Task<string[]> GetValuableFragments(string message)
+    {
+        var httpClient = new HttpClient();
+
+        var url = $"{_settings.BaseUrl}/v1/completions";
+
+        var content = new OpenAiTextCompletionRequestDto
+        {
+            model = "text-davinci-003",
+            prompt = $"{PromptTemplate}:{message}",
+            temperature = 1,
+            max_tokens = 1000,
+            top_p = 1,
+            frequency_penalty = 0,
+            presence_penalty = 0
+        };
+        var jsonContent = JsonConvert.SerializeObject(content, _jsonSettings);
+
+        var requestBody = new StringContent(jsonContent, Encoding.UTF8, "application/json");
+        var request = new HttpRequestMessage(HttpMethod.Post, url);
+        request.Content = requestBody;
+        request.Headers.Authorization = new AuthenticationHeaderValue("Bearer", _settings.ApiKey);
+            
+        var response = await httpClient.SendAsync(request);
+        var responseContent = await response.Content.ReadAsStringAsync();
+        var responseBody = JsonConvert.DeserializeObject<OpenAiTextCompletionResponseDto>(responseContent);
+
+        var valuable = responseBody?.choices?.First().text?.Replace("\n", "");
+        return valuable?.Split(";")!;
+    }
+}

--- a/api/src/Http/HighlightMessage/OpenAI/OpenAiClient.cs
+++ b/api/src/Http/HighlightMessage/OpenAI/OpenAiClient.cs
@@ -15,7 +15,7 @@ public class OpenAiClient : IHighlightMessageClient
     };
 
     private const string PromptTemplate =
-        "select 3 most important fragments in order to understand the following exception message" +
+        "select 3 most important fragments in order to understand the following exception message " +
         "and return as plain text, separated by ';' and with no additional comments:";
 
     private readonly OpenAiSettings _settings;
@@ -58,10 +58,11 @@ public class OpenAiClient : IHighlightMessageClient
         var response = await httpClient.SendAsync(request);
         if (!response.IsSuccessStatusCode)
         {
-         _logger.LogWarning(
-             "OpenAi returned {StatusCode} while getting valuable fragments from message. " +
-             "ErrorMessage: {Message}",
-             (int)response.StatusCode, JsonConvert.SerializeObject(response.Content.ReadAsStringAsync()));   
+             _logger.LogWarning(
+                 "OpenAi returned {StatusCode} while getting valuable fragments from message. " +
+                 "ErrorMessage: {Message}",
+                 (int)response.StatusCode, JsonConvert.SerializeObject(response.Content.ReadAsStringAsync()));
+             return Array.Empty<string>();
         }
         
         var responseContent = await response.Content.ReadAsStringAsync();

--- a/api/src/Http/HighlightMessage/OpenAI/OpenAiSettings.cs
+++ b/api/src/Http/HighlightMessage/OpenAI/OpenAiSettings.cs
@@ -3,6 +3,6 @@ namespace MapVault.Http.HighlightMessage.OpenAI;
 public class OpenAiSettings
 {
     public const string OpenAiConfig = "OpenAiConfig";
-    public string BaseUrl { get; set; }
-    public string ApiKey { get; set; }
+    public string? BaseUrl { get; set; }
+    public string? ApiKey { get; set; }
 }

--- a/api/src/Http/HighlightMessage/OpenAI/OpenAiSettings.cs
+++ b/api/src/Http/HighlightMessage/OpenAI/OpenAiSettings.cs
@@ -1,0 +1,8 @@
+namespace MapVault.Http.HighlightMessage.OpenAI;
+
+public class OpenAiSettings
+{
+    public const string OpenAiConfig = "OpenAiConfig";
+    public string BaseUrl { get; set; }
+    public string ApiKey { get; set; }
+}

--- a/api/src/Http/HighlightMessage/OpenAI/OpenAiTextCompletionRequestDto.cs
+++ b/api/src/Http/HighlightMessage/OpenAI/OpenAiTextCompletionRequestDto.cs
@@ -1,0 +1,12 @@
+namespace MapVault.Http.HighlightMessage.OpenAI;
+
+public class OpenAiTextCompletionRequestDto
+{
+    public string? model { get; set; }
+    public string? prompt { get; set; }
+    public int temperature { get; set; }
+    public int max_tokens { get; set; }
+    public int top_p { get; set; }
+    public int frequency_penalty { get; set; }
+    public int presence_penalty { get; set; }
+}

--- a/api/src/Http/HighlightMessage/OpenAI/OpenAiTextCompletionRequestDto.cs
+++ b/api/src/Http/HighlightMessage/OpenAI/OpenAiTextCompletionRequestDto.cs
@@ -1,3 +1,5 @@
+// ReSharper disable InconsistentNaming
+// ReSharper disable UnusedAutoPropertyAccessor.Global
 namespace MapVault.Http.HighlightMessage.OpenAI;
 
 public class OpenAiTextCompletionRequestDto

--- a/api/src/Http/HighlightMessage/OpenAI/OpenAiTextCompletionResponseDto.cs
+++ b/api/src/Http/HighlightMessage/OpenAI/OpenAiTextCompletionResponseDto.cs
@@ -1,0 +1,26 @@
+namespace MapVault.Http.HighlightMessage.OpenAI;
+
+public class OpenAiTextCompletionResponseDto
+{
+    public string? id { get; set; }
+    public string? @object { get; set; }
+    public int created { get; set; }
+    public string? model { get; set; }
+    public IEnumerable<OpenAiResponseChoice>? choices { get; set; }
+    public OpenAiResponseUsage? usage { get; set; }
+}
+
+public class OpenAiResponseChoice
+{
+    public string? text { get; set; }
+    public int index { get; set; }
+    public string? logprobs { get; set; }
+    public string? finish_reason { get; set; }
+}
+
+public class OpenAiResponseUsage
+{
+    public int prompt_tokens { get; set; }
+    public int completion_tokens { get; set; }
+    public int total_tokens { get; set; }
+}

--- a/api/src/Http/HighlightMessage/OpenAI/OpenAiTextCompletionResponseDto.cs
+++ b/api/src/Http/HighlightMessage/OpenAI/OpenAiTextCompletionResponseDto.cs
@@ -1,3 +1,5 @@
+// ReSharper disable InconsistentNaming
+// ReSharper disable UnusedMember.Global
 namespace MapVault.Http.HighlightMessage.OpenAI;
 
 public class OpenAiTextCompletionResponseDto

--- a/api/src/MapVault.csproj
+++ b/api/src/MapVault.csproj
@@ -13,7 +13,6 @@
     <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="7.0.0" />
     <PackageReference Include="MongoDB.Driver" Version="2.18.0" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.2" />
-    <PackageReference Include="Quartz" Version="3.6.2" />
     <PackageReference Include="Swashbuckle.AspNetCore" Version="6.4.0" />
   </ItemGroup>
 

--- a/api/src/MapVault.csproj
+++ b/api/src/MapVault.csproj
@@ -13,6 +13,7 @@
     <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="7.0.0" />
     <PackageReference Include="MongoDB.Driver" Version="2.18.0" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.2" />
+    <PackageReference Include="Quartz" Version="3.6.2" />
     <PackageReference Include="Swashbuckle.AspNetCore" Version="6.4.0" />
   </ItemGroup>
 

--- a/api/src/Models/ExceptionMessage.cs
+++ b/api/src/Models/ExceptionMessage.cs
@@ -12,4 +12,7 @@ public class ExceptionMessage
 
     public void RegisterValuableFragments(IEnumerable<string> valuable) =>
         Valuables = valuable;
+
+    public void ResetValuableFragments() =>
+        Valuables = null;
 }

--- a/api/src/Models/ExceptionMessage.cs
+++ b/api/src/Models/ExceptionMessage.cs
@@ -3,13 +3,13 @@ namespace MapVault.Models;
 public class ExceptionMessage
 {
     public string? Message { get; private set; }
-    public string[]? Valuables { get; private set; }
+    public IEnumerable<string>? Valuables { get; private set; }
 
     public ExceptionMessage(string? message)
     {
         Message = message;
     }
 
-    public void RegisterValuableFragments(string[] valuable) =>
+    public void RegisterValuableFragments(IEnumerable<string> valuable) =>
         Valuables = valuable;
 }

--- a/api/src/Models/ExceptionMessage.cs
+++ b/api/src/Models/ExceptionMessage.cs
@@ -1,0 +1,15 @@
+namespace MapVault.Models;
+
+public class ExceptionMessage
+{
+    public string? Message { get; private set; }
+    public string[]? Valuables { get; private set; }
+
+    public ExceptionMessage(string? message)
+    {
+        Message = message;
+    }
+
+    public void RegisterValuableFragments(string[] valuable) =>
+        Valuables = valuable;
+}

--- a/api/src/Models/Note.cs
+++ b/api/src/Models/Note.cs
@@ -38,4 +38,9 @@ public class Note : Entity
    {
       ExceptionMessage.RegisterValuableFragments(valuable);
    }
+
+   public void ResetExceptionMessageHighlights()
+   {
+      ExceptionMessage.ResetValuableFragments();
+   }
 }

--- a/api/src/Models/Note.cs
+++ b/api/src/Models/Note.cs
@@ -33,4 +33,9 @@ public class Note : Entity
       ExceptionMessage = new ExceptionMessage(exceptionMessage);
       Content = content;
    }
+
+   public void HighlightExceptionMessage(IEnumerable<string> valuable)
+   {
+      ExceptionMessage.RegisterValuableFragments(valuable);
+   }
 }

--- a/api/src/Models/Note.cs
+++ b/api/src/Models/Note.cs
@@ -7,7 +7,7 @@ public class Note : Entity
    public string? Title { get; private set; }
    public string[]? Categories { get; private set; }
    public string? Description { get; private set; }
-   public string? ExceptionMessage { get; private set; }
+   public ExceptionMessage ExceptionMessage { get; private set; }
    public string? Content { get; private set; }
    
    public Note(string? title, string[]? categories, string? description, 
@@ -19,7 +19,7 @@ public class Note : Entity
       Title = title;
       Categories = categories;
       Description = description;
-      ExceptionMessage = exceptionMessage;
+      ExceptionMessage = new ExceptionMessage(exceptionMessage);
       Content = content;
    }
 
@@ -30,7 +30,7 @@ public class Note : Entity
       Title = title;
       Categories = categories;
       Description = description;
-      ExceptionMessage = exceptionMessage;
+      ExceptionMessage = new ExceptionMessage(exceptionMessage);
       Content = content;
    }
 }

--- a/api/src/Program.cs
+++ b/api/src/Program.cs
@@ -10,6 +10,7 @@ if (!builder.Environment.IsDevelopment())
 // Add services to the container.
 builder.Services.AddPersistenceExtensions(configuration);
 builder.Services.AddDataContextExtensions();
+builder.Services.AddExternalApis();
 
 builder.Services.AddControllers();
 

--- a/api/src/Program.cs
+++ b/api/src/Program.cs
@@ -11,6 +11,7 @@ if (!builder.Environment.IsDevelopment())
 builder.Services.AddPersistenceExtensions(configuration);
 builder.Services.AddDataContextExtensions();
 builder.Services.AddExternalApis();
+builder.Services.AddUtils();
 
 builder.Services.AddControllers();
 

--- a/api/src/QueryModels/SummaryNoteQueryDto.cs
+++ b/api/src/QueryModels/SummaryNoteQueryDto.cs
@@ -1,3 +1,5 @@
+using MapVault.Models;
+
 namespace MapVault.QueryModels;
 
 public class SummaryNoteQueryDto

--- a/api/src/QueryModels/SummaryNoteQueryDto.cs
+++ b/api/src/QueryModels/SummaryNoteQueryDto.cs
@@ -1,5 +1,3 @@
-using MapVault.Models;
-
 namespace MapVault.QueryModels;
 
 public class SummaryNoteQueryDto

--- a/api/src/Repositories/NotesRepository.cs
+++ b/api/src/Repositories/NotesRepository.cs
@@ -22,18 +22,21 @@ public class NotesRepository : RepositoryBase<Note>, INotesRepository
 
    public async Task<List<SummaryNoteQueryDto>?> GetAllSummaryNotes(CancellationToken cancellationToken)
    {
-      var projectionDefinition = Builders<Note>.Projection
-         .Include(doc => doc.Id)
-         .Include(doc => doc.Title)
-         .Include(doc => doc.Categories)
-         .Include(doc => doc.Description)
-         .Include(doc => doc.ExceptionMessage);
-
+      var customProjection = Builders<Note>.Projection.Expression(u =>
+         new SummaryNoteQueryDto
+         {
+            Id = u.Id,
+            Title = u.Title,
+            Categories = u.Categories,
+            Description = u.Description,
+            ExceptionMessage = u.ExceptionMessage.Message
+         });
+      
       try
       {
          return await Collection
             .Find(new BsonDocument())
-            .Project<SummaryNoteQueryDto>(projectionDefinition)
+            .Project(customProjection)
             .ToListAsync(cancellationToken: cancellationToken);
       }
       catch (Exception e)

--- a/api/src/Utils/HighlightExceptionMessage.cs
+++ b/api/src/Utils/HighlightExceptionMessage.cs
@@ -1,0 +1,64 @@
+using System.Diagnostics;
+using MapVault.Http.HighlightMessage;
+using MapVault.Repositories;
+
+namespace MapVault.Utils;
+
+public class HighlightExceptionMessage
+{
+    private readonly ILogger<HighlightExceptionMessage> _logger;
+    private readonly IHighlightMessageClient _highlightMessageClient;
+    private readonly INotesRepository _notesRepository;
+
+    public HighlightExceptionMessage(
+        ILogger<HighlightExceptionMessage> logger,
+        IHighlightMessageClient highlightMessageClient,
+        INotesRepository notesRepository)
+    {
+        _logger = logger;
+        _highlightMessageClient = highlightMessageClient;
+        _notesRepository = notesRepository;
+    }
+
+    public async Task Highlight(Guid noteId, string message)
+    {
+        var watch = Stopwatch.StartNew();
+        _logger.LogInformation("Starting highlight exception message for note {NoteId}", noteId);
+
+        try
+        {
+            var note = await _notesRepository.GetByIdAsync(noteId, CancellationToken.None);
+            if (note is null)
+            {
+                _logger.LogWarning(
+                    "Note does not exists while trying to highlight exception message for note {NoteId}",
+                    noteId);
+                return;
+            }
+
+            var valuables = await _highlightMessageClient.GetValuableFragments(message);
+            if (!valuables.Any())
+            {
+                _logger.LogWarning("Couldn't get valuable fragments from exception message for note {NoteId}", noteId);
+                return;
+            }
+
+            note.HighlightExceptionMessage(valuables);
+
+            await _notesRepository.SaveOrUpdateAsync(note, CancellationToken.None);
+        }
+        catch (Exception e)
+        {
+            _logger.LogError(
+                "An error occurred while trying to highlight exception message for note {NoteId} " +
+                "Erro: {Message}",
+                noteId, e.Message);
+        }
+
+        watch.Stop();
+        _logger.LogInformation(
+            "Highlight exception message for note {NoteId} successfully finished. " +
+            "ElapsedMilliseconds: {ElapsedMilliseconds}",
+            noteId, watch.ElapsedMilliseconds);
+    }
+}

--- a/api/src/Utils/HighlightExceptionMessage.cs
+++ b/api/src/Utils/HighlightExceptionMessage.cs
@@ -53,6 +53,7 @@ public class HighlightExceptionMessage
                 "An error occurred while trying to highlight exception message for note {NoteId} " +
                 "Erro: {Message}",
                 noteId, e.Message);
+            return;
         }
 
         watch.Stop();

--- a/api/src/appsettings.Development.json
+++ b/api/src/appsettings.Development.json
@@ -2,6 +2,10 @@
   "ConnectionStrings": {
     "MongoDb": "mongodb://admin:01Senha!@localhost:27017"
   },
+  "OpenAiConfig": {
+    "BaseUrl": "https://api.openai.com",
+    "ApiKey": ""
+  },
   "Logging": {
     "LogLevel": {
       "Default": "Information",

--- a/api/src/scripts/mongodb/#35_atualizar_tipo_exception_message_para_object.js
+++ b/api/src/scripts/mongodb/#35_atualizar_tipo_exception_message_para_object.js
@@ -1,0 +1,14 @@
+// issue #35
+db.notes.updateMany(
+    { },
+    [
+        {
+            $addFields: {
+                exceptionMessage: {
+                    message: "$exceptionMessage",
+                    valuables: []
+                }
+            }
+        }
+    ]
+)

--- a/web/components/exceptionMsgAccordion.tsx
+++ b/web/components/exceptionMsgAccordion.tsx
@@ -5,6 +5,25 @@ type Props = {
    message: string
 }
 
+const valuable = [
+   "MongoDB.Bson.BsonSerializationException: No matching creator found.",
+   "ChooseBestCreator(Dictionary`2 values)",
+   "DeserializeClass(BsonDeserializationContext context)",
+   "ExecuteAsync(RetryableReadContext context, CancellationToken cancellationToken)",
+   "RepositoryBase`1.GetByIdAsync(Guid id, CancellationToken cancellationToken) in /Users/pedrodias/dev/mapvault/api/src/Repositories/RepositoryBase.cs:line 21",
+]
+
+function highlightValuable(content: string) {
+   var parse = require('html-react-parser')
+
+   for (let index = 0; index < valuable.length; index++) {
+      const element = valuable[index];
+      content = content.replace(element, `<strong style="background-color:#FFFF54" class="shadow-sm">${element}</strong>`);
+   }
+   
+   return parse(content)
+}
+
 const ExceptionMsgAccordion: React.FC<Props> = ({ label, message }) => {
    return (
       <div className="accordion accordion-flush" id="accordionExample">
@@ -22,7 +41,7 @@ const ExceptionMsgAccordion: React.FC<Props> = ({ label, message }) => {
                <pre className={`accordion-body fw-light ${styles.codeblock}`}
                   style={{whiteSpace: 'pre-line'}}>
                   <code>
-                     {message}
+                     {highlightValuable(message)}
                   </code>
                </pre>
             </div>

--- a/web/components/exceptionMsgAccordion.tsx
+++ b/web/components/exceptionMsgAccordion.tsx
@@ -3,7 +3,7 @@ import styles from '../styles/CodeBlock.module.css'
 type Props = {
    label: string
    message: string,
-   valuable: string[]
+   valuables: string[]
 }
 
 function highlightValuable(content: string, valuables: string[]) {

--- a/web/components/exceptionMsgAccordion.tsx
+++ b/web/components/exceptionMsgAccordion.tsx
@@ -2,29 +2,22 @@ import styles from '../styles/CodeBlock.module.css'
 
 type Props = {
    label: string
-   message: string
+   message: string,
+   valuable: string[]
 }
 
-const valuable = [
-   "MongoDB.Bson.BsonSerializationException: No matching creator found.",
-   "ChooseBestCreator(Dictionary`2 values)",
-   "DeserializeClass(BsonDeserializationContext context)",
-   "ExecuteAsync(RetryableReadContext context, CancellationToken cancellationToken)",
-   "RepositoryBase`1.GetByIdAsync(Guid id, CancellationToken cancellationToken) in /Users/pedrodias/dev/mapvault/api/src/Repositories/RepositoryBase.cs:line 21",
-]
-
-function highlightValuable(content: string) {
+function highlightValuable(content: string, valuables: string[]) {
    var parse = require('html-react-parser')
 
-   for (let index = 0; index < valuable.length; index++) {
-      const element = valuable[index];
+   for (let index = 0; index < valuables.length; index++) {
+      const element = valuables[index];
       content = content.replace(element, `<strong style="background-color:#FFFF54" class="shadow-sm">${element}</strong>`);
    }
    
    return parse(content)
 }
 
-const ExceptionMsgAccordion: React.FC<Props> = ({ label, message }) => {
+const ExceptionMsgAccordion: React.FC<Props> = ({ label, message, valuables }) => {
    return (
       <div className="accordion accordion-flush" id="accordionExample">
          <div className="accordion-item">
@@ -41,7 +34,7 @@ const ExceptionMsgAccordion: React.FC<Props> = ({ label, message }) => {
                <pre className={`accordion-body fw-light ${styles.codeblock}`}
                   style={{whiteSpace: 'pre-line'}}>
                   <code>
-                     {highlightValuable(message)}
+                     {highlightValuable(message, valuables)}
                   </code>
                </pre>
             </div>

--- a/web/components/exceptionMsgAccordion.tsx
+++ b/web/components/exceptionMsgAccordion.tsx
@@ -7,8 +7,10 @@ type Props = {
 }
 
 function highlightValuable(content: string, valuables: string[]) {
-   var parse = require('html-react-parser')
+   if (valuables === null) return content
 
+   var parse = require('html-react-parser')
+   
    for (let index = 0; index < valuables.length; index++) {
       const element = valuables[index];
       content = content.replace(element, `<strong style="background-color:#FFFF54" class="shadow-sm">${element}</strong>`);

--- a/web/interfaces/index.ts
+++ b/web/interfaces/index.ts
@@ -13,6 +13,11 @@ export type Note = {
    modifiedAt: Date | null,
    categories: string[],
    description: string,
-   exceptionMessage: string,
+   exceptionMessage: ExceptionMessage,
    content: string
+}
+
+type ExceptionMessage = {
+   message: string,
+   valuables: string[]
 }

--- a/web/pages/new.tsx
+++ b/web/pages/new.tsx
@@ -108,11 +108,10 @@ export default function New() {
                               <input className="form-check-input" type="checkbox"
                                  onClick={() => {
                                     setHighlightMessage(!highlightMessage)
-                                    console.log(highlightMessage)
                                  }} />
                               <label className="form-check-label ps-1" style={{fontSize: '14px'}}>
                                  Highlight valuable fragments from exception message
-                           </label>
+                              </label>
                            </div>
                         </div>
 

--- a/web/pages/new.tsx
+++ b/web/pages/new.tsx
@@ -110,7 +110,7 @@ export default function New() {
                                     setHighlightMessage(!highlightMessage)
                                  }} />
                               <label className="form-check-label ps-1" style={{fontSize: '14px'}}>
-                                 Highlight valuable fragments from exception message
+                                 Destacar trechos importantes da mensagem
                               </label>
                            </div>
                         </div>

--- a/web/pages/new.tsx
+++ b/web/pages/new.tsx
@@ -16,6 +16,7 @@ export default function New() {
    const [categories, setCategories] = useState('')
    const [description, setDescription] = useState('')
    const [exceptionMessage, setExceptionMessage] = useState('')
+   const [highlightMessage, setHighlightMessage] = useState(false)
    const { content, setContent } = useEditor()
 
    useEffect(() => {
@@ -32,6 +33,7 @@ export default function New() {
          categories: categoriesArray,
          description,
          exceptionMessage,
+         highlightMessage,
          content
       })
 
@@ -101,6 +103,17 @@ export default function New() {
                               type="text" className="form-control" id="floatingInput"
                               onChange={(e) => setExceptionMessage(e.target.value)} />
                            <label htmlFor="floatingInput">Exception message (opcional)</label>
+
+                           <div className="form-check pt-3 d-flex">
+                              <input className="form-check-input" type="checkbox"
+                                 onClick={() => {
+                                    setHighlightMessage(!highlightMessage)
+                                    console.log(highlightMessage)
+                                 }} />
+                              <label className="form-check-label ps-1" style={{fontSize: '14px'}}>
+                                 Highlight valuable fragments from exception message
+                           </label>
+                           </div>
                         </div>
 
                         <Editor />

--- a/web/pages/note/[id].tsx
+++ b/web/pages/note/[id].tsx
@@ -26,7 +26,8 @@ export default function NotePage() {
    const [description, setDescription] = useState('')
    const [editExMessageToogle, setEditExMessageToogle] = useState(false)
    const [exMessage, setExMessage] = useState('')
-   const [exMessageValuables, setExMessageValuables] = useState([''])
+   const [exMessageValuables, setExMessageValuables] = useState<string[]>([])
+   const [highlightMessageOption, setHighlightMessageOption] = useState(false)
    const [editCategoriesToogle, setEditCategoriesToogle] = useState(false)
    const [categories, setCategories] = useState('')
    const [categoriesArray, setCategoriesArray] = useState([''])
@@ -40,6 +41,7 @@ export default function NotePage() {
          setDescription(data.description)
          setExMessage(data.exceptionMessage.message)
          setExMessageValuables(data.exceptionMessage.valuables)
+         setHighlightMessageOption(data.exceptionMessage?.valuables?.length > 0)
          setCategories(data.categories.join(', '))
       }
    }, [data])
@@ -62,6 +64,7 @@ export default function NotePage() {
          description: description,
          categories: categoriesArray,
          exceptionMessage: exMessage,
+         highlightMessage: highlightMessageOption,
          content: content
       })
       
@@ -221,7 +224,22 @@ export default function NotePage() {
 
                   {/* Exception message */}
                   {editExMessageToogle == true
-                     ? EditTextInput('Editando Exception Message', exMessage, handleEditExMessageToogle, setExMessage)
+                     ? (
+                        <>
+                           {EditTextInput('Editando Exception Message', exMessage, handleEditExMessageToogle, setExMessage)}
+                           <div className="form-check d-flex">
+                              <input className="form-check-input" type="checkbox" 
+                                 checked={highlightMessageOption}
+                                 onChange={() => {
+                                    setHighlightMessageOption(!highlightMessageOption)
+                                 }} 
+                              />
+                              <label className="form-check-label ps-1" style={{fontSize: '14px'}}>
+                                 Highlight valuable fragments from exception message
+                              </label>
+                           </div>
+                        </>
+                     )
                      : null
                   }
 
@@ -326,13 +344,13 @@ export default function NotePage() {
                   {!exMessage && !editExMessageToogle
                      ? <button className="btn btn-link text-primary-emphasis"
                            onClick={() => {
-                              setEditExMessageToogle(true)
+                              setEditExMessageToogle(!editExMessageToogle)
                            }}>
                         Add an exception message
                      </button>
                      : <button className="btn btn-link text-secondary-emphasis"
                         onClick={() => {
-                           setEditExMessageToogle(true)
+                           setEditExMessageToogle(!editExMessageToogle)
                         }}>
                         Edit exception message
                      </button>}

--- a/web/pages/note/[id].tsx
+++ b/web/pages/note/[id].tsx
@@ -37,7 +37,7 @@ export default function NotePage() {
          setContent(data.content)
          setTitle(data.title)
          setDescription(data.description)
-         setExMessage(data.exceptionMessage)
+         setExMessage(data.exceptionMessage.message)
          setCategories(data.categories.join(', '))
       }
    }, [data])

--- a/web/pages/note/[id].tsx
+++ b/web/pages/note/[id].tsx
@@ -26,6 +26,7 @@ export default function NotePage() {
    const [description, setDescription] = useState('')
    const [editExMessageToogle, setEditExMessageToogle] = useState(false)
    const [exMessage, setExMessage] = useState('')
+   const [exMessageValuables, setExMessageValuables] = useState([''])
    const [editCategoriesToogle, setEditCategoriesToogle] = useState(false)
    const [categories, setCategories] = useState('')
    const [categoriesArray, setCategoriesArray] = useState([''])
@@ -38,6 +39,7 @@ export default function NotePage() {
          setTitle(data.title)
          setDescription(data.description)
          setExMessage(data.exceptionMessage.message)
+         setExMessageValuables(data.exceptionMessage.valuables)
          setCategories(data.categories.join(', '))
       }
    }, [data])
@@ -226,7 +228,8 @@ export default function NotePage() {
                   {exMessage
                      ? <ExceptionMsgAccordion 
                         label={editExMessageToogle ? 'Preview exception message' : 'Exception Message'}
-                        message={exMessage} />
+                        message={exMessage}
+                        valuables={exMessageValuables} />
                      : null
                   }
 

--- a/web/pages/note/[id].tsx
+++ b/web/pages/note/[id].tsx
@@ -235,7 +235,7 @@ export default function NotePage() {
                                  }} 
                               />
                               <label className="form-check-label ps-1" style={{fontSize: '14px'}}>
-                                 Highlight valuable fragments from exception message
+                                 Destacar trechos importantes da mensagem
                               </label>
                            </div>
                         </>


### PR DESCRIPTION
Closes #35 

Criar funcionalidade para destacar trechos importantes de exception message de uma nota.

- Permitir escolher quando destacar na tela de criar novo `/new`
- Permitir escolher se quer manter os destaques ao editar na tela `/note/[id]`
- No backend, enviar a exception message para a OpenAI API para obter os trechos para destacar e persistir no objecto ExceptionMessage (novo), que agora tem tanto a mensagem como um array de trechos importantes.
- Criado endpoint para obter lista de destaques de uma mensagem `GET api/v1/highlight`, que recebe o atributo `message` no body

<img width="1203" alt="Captura de Tela 2023-03-02 às 13 23 08" src="https://user-images.githubusercontent.com/50634340/222488898-3e2d5d76-497c-4f8e-9fa8-ef0db772b6d4.png">

<img width="1203" alt="Captura de Tela 2023-03-02 às 13 22 07" src="https://user-images.githubusercontent.com/50634340/222488466-12d4a336-5ea3-40fb-acda-bd985723c68a.png">

<img width="1437" alt="Captura de Tela 2023-03-02 às 12 35 50" src="https://user-images.githubusercontent.com/50634340/222474975-9f9bae12-8abe-45c0-b7c5-64da8f7f04dd.png">
